### PR TITLE
Testnet support

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -13,7 +13,7 @@ module.exports = function (config) {
     logLevel: config.LOG_WARN,
 
     client: {
-      captureConsole: true
+      captureConsole: false
     },
 
     autoWatch: true,

--- a/src/api.js
+++ b/src/api.js
@@ -41,6 +41,7 @@ class API extends Exchange.API {
   }
 
   _url (endpoint) {
+    endpoint = endpoint || '';
     return `https://app-api${this._testnet ? '.sandbox' : ''}.coinify.com/${endpoint}`;
   }
 

--- a/src/api.js
+++ b/src/api.js
@@ -5,7 +5,6 @@ class API extends Exchange.API {
   constructor () {
     super();
     this._offlineToken = null;
-    this._rootURL = 'https://app-api.coinify.com/';
     this._loginExpiresAt = null;
   }
 
@@ -41,10 +40,12 @@ class API extends Exchange.API {
     return promise;
   }
 
+  _url (endpoint) {
+    return `https://app-api${this._testnet ? '.sandbox' : ''}.coinify.com/${endpoint}`;
+  }
+
   _request (method, endpoint, data, authorized) {
     assert(!authorized || this.isLoggedIn, "Can't make authorized request if not logged in");
-
-    var url = this._rootURL + endpoint;
 
     var headers = {};
 
@@ -52,7 +53,7 @@ class API extends Exchange.API {
       headers['Authorization'] = 'Bearer ' + this._access_token;
     }
 
-    return super._request(method, url, data, headers);
+    return super._request(method, this._url(endpoint), data, headers);
   }
 
   _authRequest (method, endpoint, data) {

--- a/tests/api_spec.js
+++ b/tests/api_spec.js
@@ -67,6 +67,21 @@ describe('Coinify API', function () {
       });
     });
 
+    describe('_url', () => {
+      it('should use app-api.coinify.com by default', () => {
+        expect(api._url()).toEqual('https://app-api.coinify.com/');
+      });
+
+      it('should use sandbox for testnet', () => {
+        api._testnet = true;
+        expect(api._url()).toEqual('https://app-api.sandbox.coinify.com/');
+      });
+
+      it('should include the endpoint', () => {
+        expect(api._url('endpoint')).toEqual('https://app-api.coinify.com/endpoint');
+      });
+    });
+
     describe('login', function () {
       beforeEach(function () {
         api._user = 'user-1';

--- a/tests/api_spec.js
+++ b/tests/api_spec.js
@@ -14,9 +14,9 @@ describe('Coinify API', function () {
 
   describe('class', () =>
     describe('new API()', () =>
-      it('should have a root URL', function () {
+      it('should have a null _offlineToken', function () {
         api = new API();
-        expect(api._rootURL).toBeDefined();
+        expect(api._offlineToken).toEqual(null);
       })
     )
   );


### PR DESCRIPTION
The Coinify `sandbox` API uses testnet. Use `coinify.api.testnet = true;` to use it.

`this._testnet` is false by default, as of the latest `bitcoin-exchange-client`.

I believe this is safe to merge with just a patch version increase, since the behavior doesn't change when testnet is false.