### PR TITLE
fix(Coinify): Adding public setters to user and offlineToken for mobile support

### DIFF
--- a/src/coinify.js
+++ b/src/coinify.js
@@ -53,6 +53,14 @@ class Coinify extends Exchange.Exchange {
   set partnerId (value) {
     this._partner_id = value;
   }
+  
+  set user (value) {
+	  this._user = value;
+  }
+  
+  set offlineToken (value) {
+	  this._offlineToken = value;
+  }
 
   get buyCurrencies () { return this._buyCurrencies; }
 


### PR DESCRIPTION
iOS needs to be able to set the `user` identifier and `offlineToken` from `wallet-ios`. 